### PR TITLE
Fix/input

### DIFF
--- a/src/components/forms/checkbox/CheckBox.tsx
+++ b/src/components/forms/checkbox/CheckBox.tsx
@@ -4,13 +4,14 @@
  * @param {} param desc
  * @returns returns desc
  */
-//! needs to handle onChange
+
 import React from 'react';
 import { CheckBoxStyles } from '@/components/forms/checkbox/CheckBoxStyles';
 import { FormDescription } from '@/components/forms/description/FormDescription';
 import { FormGroupStyles } from '@/components/forms/group/FormGroupStyles';
 
 interface CheckBoxProps {
+  handleOnChange(event: React.FormEvent<HTMLFieldSetElement>):void;
   description?: String;
   legend?: String;
   isGroup?: boolean;
@@ -22,10 +23,11 @@ export const CheckBox: React.FC<CheckBoxProps> = ({
   description,
   legend,
   isGroup,
+  handleOnChange,
 }): JSX.Element => {
   return (
     <CheckBoxStyles>
-      <fieldset>
+      <fieldset {...(handleOnChange && { onChange: handleOnChange })}>
         {legend && <legend>{legend}</legend>}
         {description && <FormDescription description={description} />}
         {isGroup ? <FormGroupStyles>{children}</FormGroupStyles> : children}

--- a/src/components/forms/input/Input.tsx
+++ b/src/components/forms/input/Input.tsx
@@ -25,9 +25,10 @@ export const Input: React.FC<InputProps> = ({
   label,
   value,
 }): JSX.Element => {
+  const types = ['radio', 'checkbox']
   return (
     <>
-      {label && <label htmlFor={id}>{label}</label>}
+      {label && !types.includes(inputType) && <label htmlFor={id}>{label}</label>}
       <input
         {...(handleOnChange && { onChange: handleOnChange })}
         id={id}
@@ -36,6 +37,7 @@ export const Input: React.FC<InputProps> = ({
         placeholder={placeholder}
         value={value}
       />
+      {label && types.includes(inputType) && <label htmlFor={id}>{label}</label>}
     </>
   );
 };

--- a/src/components/forms/radio/Radio.tsx
+++ b/src/components/forms/radio/Radio.tsx
@@ -12,6 +12,7 @@ import { FormDescription } from '@/components/forms/description/FormDescription'
 import { FormGroupStyles } from '@/components/forms/group/FormGroupStyles';
 
 interface RadioProps {
+  handleOnChange(event: React.FormEvent<HTMLFieldSetElement>):void;
   description?: String;
   legend?: String;
   isGroup?: boolean;
@@ -23,10 +24,11 @@ export const Radio: React.FC<RadioProps> = ({
   description,
   legend,
   isGroup,
+  handleOnChange,
 }): JSX.Element => {
   return (
     <RadioStyles>
-      <fieldset>
+      <fieldset {...(handleOnChange && { onChange: handleOnChange })}>
         {legend && <legend>{legend}</legend>}
         {description && <FormDescription description={description} />}
         {isGroup ? <FormGroupStyles>{children}</FormGroupStyles> : children}


### PR DESCRIPTION
For Radio and Checkbox, label should be after input, otherwise it doesn't work properly. I put a condition to check if it's radio or checkbox, then the label will appear after the input field.